### PR TITLE
Bugfix 1.1.1 and new option/feature

### DIFF
--- a/CSL-Traffic.csproj
+++ b/CSL-Traffic.csproj
@@ -34,13 +34,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="ColossalManaged">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
+      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
     </Reference>
     <Reference Include="ICities">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
+      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\ICities.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -49,7 +49,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSL-Traffic.csproj
+++ b/CSL-Traffic.csproj
@@ -34,13 +34,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="ColossalManaged">
-      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
     </Reference>
     <Reference Include="ICities">
-      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\ICities.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -49,7 +49,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UnityEngine">
-      <HintPath>E:\Games\Cities Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSL-Traffic/AI/Vehicles/CustomCarAI.cs
+++ b/CSL-Traffic/AI/Vehicles/CustomCarAI.cs
@@ -416,7 +416,7 @@ namespace CSL_Traffic
                     }
                 }
             }
-            if (lodPhysics == 0)
+            if (lodPhysics == 0 && (CSLTraffic.Options & OptionsManager.ModOptions.noStopForCrossing) != OptionsManager.ModOptions.noStopForCrossing)
             {
                 CitizenManager instance2 = Singleton<CitizenManager>.instance;
                 float num7 = 0f;

--- a/CSL-Traffic/AI/Vehicles/CustomCargoTruckAI.cs
+++ b/CSL-Traffic/AI/Vehicles/CustomCargoTruckAI.cs
@@ -124,7 +124,7 @@ namespace CSL_Traffic
 				{
 					endPosB = default(PathUnit.Position);
 				}
-				NetInfo.LaneType laneTypes = NetInfo.LaneType.Vehicle | NetInfo.LaneType.Cargo;
+                NetInfo.LaneType laneTypes = NetInfo.LaneType.Vehicle | NetInfo.LaneType.CargoVehicle;
 				VehicleInfo.VehicleType vehicleTypes = VehicleInfo.VehicleType.Car | VehicleInfo.VehicleType.Train | VehicleInfo.VehicleType.Ship;
 				uint path;
 				bool createPathResult;

--- a/CSL-Traffic/AI/Vehicles/CustomVehicleAI.cs
+++ b/CSL-Traffic/AI/Vehicles/CustomVehicleAI.cs
@@ -49,7 +49,7 @@ namespace CSL_Traffic
             {
                 if ((b & 1) == 0)
                 {
-                    if (lane.m_laneType != NetInfo.LaneType.Cargo)
+                    if (lane.m_laneType != NetInfo.LaneType.CargoVehicle)
                     {
                         bool flag = true;
                         while (b2 != position.m_offset)
@@ -182,7 +182,7 @@ namespace CSL_Traffic
                     }
                     return;
                 }
-                if ((byte)(lane2.m_laneType & (NetInfo.LaneType.Vehicle | NetInfo.LaneType.Cargo | ((NetInfo.LaneType)((byte)32)) | ((NetInfo.LaneType)((byte)64)))) == 0)
+                if ((byte)(lane2.m_laneType & (NetInfo.LaneType.Vehicle | NetInfo.LaneType.CargoVehicle | ((NetInfo.LaneType)((byte)32)) | ((NetInfo.LaneType)((byte)64)))) == 0)
                 {
                     (vehicleAI as IVehicle).InvalidPath(vehicleID, ref vehicleData, vehicleID, ref vehicleData);
                     return;
@@ -220,7 +220,7 @@ namespace CSL_Traffic
                 }
                 else
                 {
-                    if (num3 != laneID && lane.m_laneType != NetInfo.LaneType.Cargo)
+                    if (num3 != laneID && lane.m_laneType != NetInfo.LaneType.CargoVehicle)
                     {
                         PathUnit.CalculatePathPositionOffset(laneID, vector, out b4);
                         bezier = default(Bezier3);

--- a/CSL-Traffic/OptionsManager.cs
+++ b/CSL-Traffic/OptionsManager.cs
@@ -20,7 +20,7 @@ namespace CSL_Traffic
 			UseRealisticSpeeds = 8,
 			NoDespawn = 16,
 			ImprovedAI = 32,
-
+			noStopForCrossing = 33,
 			// bits 55 to 62 reserved for beta tests that won't have their own option
 			//BetaTestNewRoads = 1L << 54,
 			BetaTestRoadCustomizerTool = 1L << 55,
@@ -50,6 +50,7 @@ namespace CSL_Traffic
 		UICheckBox m_improvedAICheckBox = null;
 		UICheckBox m_betaTestRoadCustomizerCheckBox = null;
 		UICheckBox m_ghostModeCheckBox = null;
+		UICheckBox m_noStopForCrossing = null;
 
 		bool m_initialized;
 
@@ -171,6 +172,7 @@ namespace CSL_Traffic
 			m_realisticSpeedsCheckBox = AddOptionCheckbox("Beta Test: Realistic Speeds", 4);
 			m_betaTestRoadCustomizerCheckBox = AddOptionCheckbox("Beta Test: Road Customizer Tool", 5);
 			m_improvedAICheckBox = AddOptionCheckbox("Beta Test: Improved AI", 6);
+			m_noStopForCrossing = AddOptionCheckbox("Beta Test: Cars drive trough pedestrian crossings", 7);
 
 			m_ghostModeCheckBox = AddOptionCheckbox("Ghost Mode (disables all mod functionality leaving only enough logic to load the map)");
 			m_ghostModeCheckBox.gameObject.transform.SetParent(m_optionsPanel.transform);
@@ -251,6 +253,11 @@ namespace CSL_Traffic
 				options.betaTestRoadCustomizer = true;
 				CSLTraffic.Options |= ModOptions.BetaTestRoadCustomizerTool;
 			}
+			if (this.m_noStopForCrossing.isChecked)
+			{
+				options.noStopForCrossing = true;
+				CSLTraffic.Options |= ModOptions.noStopForCrossing;
+			}
 			if (this.m_ghostModeCheckBox.isChecked)
 			{
 				options.ghostMode = true;
@@ -304,6 +311,7 @@ namespace CSL_Traffic
 				this.m_improvedAICheckBox.isChecked = options.improvedAI;
 				this.m_betaTestRoadCustomizerCheckBox.isChecked = options.betaTestRoadCustomizer;
 				this.m_ghostModeCheckBox.isChecked = options.ghostMode;
+				this.m_noStopForCrossing.isChecked = options.noStopForCrossing;
 			}
 
 			if (options.allowTrucks)
@@ -323,6 +331,9 @@ namespace CSL_Traffic
 
 			if (options.improvedAI)
 				CSLTraffic.Options |= ModOptions.ImprovedAI;
+
+			if (options.noStopForCrossing)
+				CSLTraffic.Options |= ModOptions.noStopForCrossing;
 
 			if (options.betaTestRoadCustomizer)
 				CSLTraffic.Options |= ModOptions.BetaTestRoadCustomizerTool;
@@ -359,6 +370,8 @@ namespace CSL_Traffic
 			public bool realisticSpeeds;
 			public bool noDespawn;
 			public bool improvedAI;
+
+			public bool noStopForCrossing;
 
 			public bool betaTestRoadCustomizer;
 

--- a/CSL-Traffic/Transports/BusTransportLineAI.cs
+++ b/CSL-Traffic/Transports/BusTransportLineAI.cs
@@ -71,7 +71,7 @@ namespace CSL_Traffic
 			PathUnit.Position startPosB;
 			float num;
 			float num2;
-			if (!PathManager.FindPathPosition(position, netService, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, true, 32f, out startPosA, out startPosB, out num, out num2))
+			if (!PathManager.FindPathPosition(position, netService, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, true, false, 32f, out startPosA, out startPosB, out num, out num2))
 			{
 				return true;
 			}
@@ -79,7 +79,7 @@ namespace CSL_Traffic
 			PathUnit.Position endPosB;
 			float num3;
 			float num4;
-			if (!PathManager.FindPathPosition(position2, netService, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, true, 32f, out endPosA, out endPosB, out num3, out num4))
+			if (!PathManager.FindPathPosition(position2, netService, NetInfo.LaneType.Pedestrian, VehicleInfo.VehicleType.None, true, false, 32f, out endPosA, out endPosB, out num3, out num4))
 			{
 				return true;
 			}


### PR DESCRIPTION
I've fixed the crash when creating a bus line on 1.1.1.
The problem was in the `PathManager.FindPathPosition()` function. It required a extra argument.

I've also added the option to disable the slowdown/stop for pedestrian crossings. This might be a little less realistic (eg. cars plowing though people), but it helps a lot with traffic problems in game.
